### PR TITLE
AnyEditTools Eclipse update site is moved 

### DIFF
--- a/mirror-non-p2/pom.xml
+++ b/mirror-non-p2/pom.xml
@@ -32,7 +32,7 @@
                         <configuration>
                             <source>
                                 <repository>
-                                    <url>http://andrei.gmxhome.de/eclipse</url>
+                                    <url>https://raw.githubusercontent.com/iloveeclipse/plugins/latest</url>
                                 </repository>
                                 <repository>
                                     <url>http://dadacoalition.org/yedit</url>

--- a/target-platform/idealized-target.target
+++ b/target-platform/idealized-target.target
@@ -53,7 +53,7 @@
         </location>
         <!-- non-p2: <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="AnyEditTools.feature.group" version="0.0.0"/>
-            <repository location="http://andrei.gmxhome.de/eclipse/"/>
+            <repository location="https://raw.githubusercontent.com/iloveeclipse/plugins/latest/"/>
         </location> -->
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="de.jcup.batcheditor.feature.group" version="0.0.0"/>


### PR DESCRIPTION
From http://andrei.gmxhome.de/eclipse/ to https://raw.githubusercontent.com/iloveeclipse/plugins/latest/

See http://javaclipse.blogspot.com/2020/11/my-main-update-site-moved.html

Checked with Andrey Loskutov

